### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Winston logger with custom 5A configuration",
   "main": "src/main.js",
   "dependencies": {
-    "winston": "^2.4.3",
-    "winston-raven-sentry": "^1.0.1"
+    "winston": "^3.1.0",
+    "winston-raven-sentry": "^2.0.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,10 @@
-const winston = require('winston');
+const { transports, createLogger } = require('winston');
 const Sentry = require('winston-raven-sentry');
 
 function getLogger(mod) {
   const path = mod.filename.split('/').slice(-2).join('/');
-  const transports = [
-    new (winston.transports.Console)({
+  const winstonTransports = [
+    new (transports.Console)({
       timestamp: true,
       colorize: false,
       level: process.env.CONSOLE_LOG_LEVEL || 'info',
@@ -26,7 +26,9 @@ function getLogger(mod) {
     }));
   }
 
-  return new (winston.Logger)({transports});
+  return createLogger({
+    transports: winstonTransports,
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
# What does this PR do?

- It upgrades the `winston` lib to the last version `3.1.0`.
- It upgrades the `winston-raven-sentry` lib to the last version `2.0.0`.

### Why?
The previous version of `winston` can't handle circular dependencies in the error object.