### PR TITLE
[FBI-148] - Make sentry log unhandled promise rejections

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Winston logger with sentry configuration included. Also show the file from which
 | SENTRY_ENVIRONMENT   | The environment running (dev, staging, prod) |
 | SENTRY_RELEASE       | The current release                          |
 | CONSOLE_LOG_LEVEL    | The level of the logs displayed on the console (optional, defaults to info) |
+| CAPTURE_UNHANDLED_REJECTIONS  | A value (true or false) saying if you want these exceptions to be logged in you app |
 
 ## Usage
 

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,9 @@ function getLogger(mod) {
         app: process.env.SENTRY_APP,
         environment: process.env.SENTRY_ENVIRONMENT,
       },
+      config: { 
+        captureUnhandledRejections: CAPTURE_UNHANDLED_REJECTIONS || false,
+      },
       release: process.env.SENTRY_RELEASE,
       install: true,
     }));


### PR DESCRIPTION
We would like to log unhandled promise rejections on Sentry and to do that we need to pass a config object with `captureUnhandledRejections: true`. 
However, we do not know if all projects will want to do that and so we are receiving this config from an `env` variable and setting `captureUnhandledRejections` to its value. If this env variable does not exist, `captureUnhandledRejections` is set to false.