### PR TITLE
Fix Logger Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quintoandar-logger",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,6 +24,13 @@
         "@sentry/types": "5.27.2",
         "@sentry/utils": "5.27.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+          "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+        }
       }
     },
     "@sentry/hub": {
@@ -34,6 +41,13 @@
         "@sentry/types": "5.27.2",
         "@sentry/utils": "5.27.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+          "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+        }
       }
     },
     "@sentry/minimal": {
@@ -44,6 +58,13 @@
         "@sentry/hub": "5.27.2",
         "@sentry/types": "5.27.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+          "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+        }
       }
     },
     "@sentry/node": {
@@ -60,6 +81,13 @@
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+          "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+        }
       }
     },
     "@sentry/tracing": {
@@ -72,12 +100,20 @@
         "@sentry/types": "5.27.2",
         "@sentry/utils": "5.27.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+          "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+        }
       }
     },
     "@sentry/types": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
-      "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-kIaN52Fw5K+2mKRaHE2YluJ+F/qMGSUzZXIFDNdC6OUMXQ4TM8gZTrITXs8CLDm7cK8iCqFCtzKOjKK6KyOKAg==",
+      "dev": true
     },
     "@sentry/utils": {
       "version": "5.27.2",
@@ -86,6 +122,13 @@
       "requires": {
         "@sentry/types": "5.27.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+          "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+        }
       }
     },
     "agent-base": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0"
   },
+  "devDependencies": {
+    "@sentry/types": "^6.1.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quintoandar-logger",
-  "version": "3.3.0",
+  "version": "3.3.3",
   "description": "Winston logger with custom 5A configuration",
   "main": "src/main.js",
   "dependencies": {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,5 @@
 declare module quintoandar_logger {
-
-    type Sentry = import('@sentry/node').Sentry
+    type Sentry = typeof import('@sentry/node')
     type SentryParams = import('@sentry/node').NodeOptions
 
     type LoggerMethod = import('winston').LeveledLogMethod
@@ -12,15 +11,16 @@ declare module quintoandar_logger {
         readonly active: boolean;
     }
 
-
     function getLogger(mod: NodeModule): Logger
     function setTracer(newTracer: TracerBase): QuintoLogger
     function startSentry(newSentryParams: SentryParams): QuintoLogger
     function startSentry(newSentryParams: SentryParams, sentryFunc: SentryFunc): QuintoLogger
+    
     interface QuintoLogger {
         getLogger: typeof getLogger
         setTracer: typeof setTracer
         startSentry: typeof startSentry
     }
 }
+
 export = quintoandar_logger

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,7 +6,7 @@ declare module quintoandar_logger {
     type LogLevels = "error" | "warn" | "debug" | "info"
     type Logger = Record<LogLevels, LoggerMethod>
 
-    type SentryFunc = ((Sentry) => void)
+    type SentryFunc = ((Sentry: Sentry) => void)
     type TracerBase = {
         readonly active: boolean;
     }


### PR DESCRIPTION
`@sentry/node` doesn't have a `Sentry` module. We want the type of the main module. It raises a `has no exported member 'Sentry'.` error.

Also
- Add official sentry types
- Fix package version