### PR TITLE
Feature/add sentry team tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ At your console, the logs now contain the trace-id identifier:
 [info] Some info about processing cool object with id 11 [trace-id: TRACER-ID] { extra: { id: 11, someInfo: 'someInfo' } }, module: 'path/to/my/file.js', timestamp: '2020-06-09T22:46:21.759Z'}
 ```
 
+### Team
+We have added a new concept that allow define a team that own the error.
+
+If you create a custom error that contains a _team_ property, this value will appear as _team_ tag on sentry. It is useful in cross applications, like jaiminho, us-emails, markito, etc, because we can group error by team
+
 ## TODO
 
 - Create Express Middleware Request Logger

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Winston logger with custom 5A configuration",
   "main": "src/main.js",
   "dependencies": {
-    "@sentry/node": "^6.2.0",
+    "@sentry/node": "^6.1.0",
     "lodash": "^4.17.20",
     "stack-trace": "0.0.10",
     "util": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Winston logger with custom 5A configuration",
   "main": "src/main.js",
   "dependencies": {
-    "@sentry/node": "^6.1.0",
+    "@sentry/node": "^5.30.0",
     "lodash": "^4.17.20",
     "stack-trace": "0.0.10",
     "util": "^0.12.3",
@@ -12,7 +12,7 @@
     "winston-transport": "^4.4.0"
   },
   "devDependencies": {
-    "@sentry/types": "^6.2.0"
+    "@sentry/types": "^6.1.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "quintoandar-logger",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Winston logger with custom 5A configuration",
   "main": "src/main.js",
   "dependencies": {
-    "@sentry/node": "^5.27.2",
+    "@sentry/node": "^6.2.0",
     "lodash": "^4.17.20",
     "stack-trace": "0.0.10",
     "util": "^0.12.3",
@@ -12,7 +12,7 @@
     "winston-transport": "^4.4.0"
   },
   "devDependencies": {
-    "@sentry/types": "^6.1.0"
+    "@sentry/types": "^6.2.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/main.js
+++ b/src/main.js
@@ -94,6 +94,10 @@ function formatParams(params, module, funcCallerParam) {
         }
     }
 
+    if (metadata.error && metadata.error.team) {
+        metadata.team = metadata.error.team
+    }
+
     if(module) {
         metadata.module = module;
     }

--- a/src/transports.js
+++ b/src/transports.js
@@ -54,6 +54,9 @@ class SentryTransport extends Transport {
             if (info.traceId) {
                 scope.setTag("traceId", info.traceId)
             }
+            if(info.team) {
+                scope.setTag('team', info.team)
+            }
             scope.setContext(info)
             scope.setExtras(info);
             if (thereIsErrorExtraData) {

--- a/src/transports.js
+++ b/src/transports.js
@@ -54,7 +54,7 @@ class SentryTransport extends Transport {
             if (info.traceId) {
                 scope.setTag("traceId", info.traceId)
             }
-            if(info.team) {
+            if (info.team) {
                 scope.setTag('team', info.team)
             }
             scope.setContext(info)


### PR DESCRIPTION
Allow define a team tag on sentry to identify the team that owns the failure