### PR TITLE
Log all span ids

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -59,10 +59,9 @@ function formatParams(params, module, funcCallerParam) {
     const metadata = {};
 
     if (tracer && tracer.currentRootSpan && tracer.currentRootSpan.traceId) {
+        const allDescendants = tracer.currentRootSpan.allDescendants().map((span) => span.id)
         metadata.traceId = tracer.currentRootSpan.traceId;
-        if (tracer.currentRootSpan.spanContext && tracer.currentRootSpan.spanContext.spanId) {
-            metadata.spanId = tracer.currentRootSpan.spanContext.spanId;
-        }
+        metadata.spanIds = [tracer.currentRootSpan.parentSpanId, tracer.currentRootSpan.id, allDescendants].flat()
     }
 
     if (typeof params[0] === 'string') {


### PR DESCRIPTION
**What & Why**

This add more tracing context to every log message. It logs the parent span id that originated the root span for the component, the root span id of the component, and all the current child span ids for subcomponents.

We will use this group logs per components in comms console.

```
[info] Received async request [trace-id: 0b9854457c944d0fa6796b4351856809] { spanIds: [ '789', 'c5585a073f6a6f6a' ], module: 'controllers/sendmail.js', timestamp: '2023-02-07T19:39:32.847Z'}
```